### PR TITLE
Dependencies in the right manner

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "scripts": {
     "test": "cd tests && ./run-tests"
   },
-  "devDependencies": {
+  "dependencies": {
     "async": ">=0.2.9",
-    "redis": ">=0.8.4"
+    "redis": ">=0.8.4",
+    "cidr_match": ">=0.0.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #16

Not only that, your dependencies are needed on production so they are actually `dependencies`, not `devDependencies`.

Cheers!
