### PR TITLE
Change message blocked IP spam message

### DIFF
--- a/plugins/20-ip.js
+++ b/plugins/20-ip.js
@@ -147,7 +147,7 @@ exports.testJSON = function ( obj, spam, ok, next )
             //
             // Send the reply.
             //
-            spam( reply );
+            spam("IP previously blocked: " + reply);
         }
         else {
             next("next");


### PR DESCRIPTION
If an IP has submitted a previously blocked message, it would use the old message. This makes the spam reason a bit more explicit.

(When I tried integrating, my first try was using 127.0.0.1 as the commenter IP, which was already blocked for bad content. It took a bit of head scratching to figure it out.)
